### PR TITLE
Add model factories and a database seeder (#8, #9)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
     "license": "MIT",
     "autoload": {
         "psr-4": {
-            "STS\\Beankeep\\": "src/"
+            "STS\\Beankeep\\": "src/",
+            "STS\\Beankeep\\Database\\Factories\\": "database/factories/"
         }
     },
     "authors": [
@@ -25,7 +26,6 @@
         "illuminate/database": "^10.0",
         "nunomaduro/collision": "^7.7"
     },
-
     "extra": {
         "laravel": {
             "providers": [

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
     "autoload": {
         "psr-4": {
             "STS\\Beankeep\\": "src/",
-            "STS\\Beankeep\\Database\\Factories\\": "database/factories/"
+            "STS\\Beankeep\\Database\\Factories\\": "database/factories/",
+            "STS\\Beankeep\\Database\\Seeders\\": "database/seeders/"
         }
     },
     "authors": [

--- a/database/factories/AccountFactory.php
+++ b/database/factories/AccountFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace STS\Beankeep\Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;

--- a/database/factories/AccountFactory.php
+++ b/database/factories/AccountFactory.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace STS\Beankeep\Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use STS\Beankeep\Enums\AccountType;
+use STS\Beankeep\Models\Account;
+
+class AccountFactory extends Factory
+{
+    protected $model = Account::class;
+
+    public function definition(): array
+    {
+        return [];
+    }
+}

--- a/database/factories/LineItemFactory.php
+++ b/database/factories/LineItemFactory.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace STS\Beankeep\Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
-use STS\Beankeep\Models\Account;
+use STS\Beankeep\Models\LineItem;
 
-class AccountFactory extends Factory
+class LineItemFactory extends Factory
 {
-    protected $model = Account::class;
+    protected $model = LineItem::class;
 
     public function definition(): array
     {

--- a/database/factories/SourceDocumentFactory.php
+++ b/database/factories/SourceDocumentFactory.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace STS\Beankeep\Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+use STS\Beankeep\Models\SourceDocument;
+
+class SourceDocumentFactory extends Factory
+{
+    protected $model = SourceDocument::class;
+
+    protected static array $extensions = [
+        'bmp',
+        'c',
+        'cpp',
+        'csv',
+        'doc',
+        'docx',
+        'gif',
+        'htm',
+        'html',
+        'jpeg',
+        'jpg',
+        'js',
+        'lua',
+        'pdf',
+        'php',
+        'pl',
+        'png',
+        'py',
+        'rb',
+        'rtf',
+        'svg',
+        'tif',
+        'tiff',
+        'txt',
+        'webp',
+        'xhtml',
+        'xls',
+        'xlsx',
+        'xml',
+    ];
+
+    public function definition(): array
+    {
+        $memo = $this->memo();
+        $filename = Str::kebab($memo) . '.' . $this->extension();
+
+        return [
+            'memo' => $memo,
+            'attachment' => Str::uuid()->toString(),
+            'filename' => $filename,
+            'mime_type' => static::mime($filename),
+        ];
+    }
+
+    protected function memo(): string
+    {
+        $numWords = $this->faker->numberBetween(3, 7);
+
+        return implode(' ', $this->faker->words($numWords));
+    }
+
+    public function extension(): string
+    {
+        return $this->faker->randomElement(static::$extensions);
+    }
+
+    public static function mime(string $filename): string
+    {
+        $parts = explode('.', $filename);
+        $extension = end($parts);
+
+        return match($extension) {
+            'bmp' => 'image/bmp',
+            'csv' => 'text/csv',
+            'doc' => 'application/msword',
+            'docx' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+            'gif' => 'image/gif',
+            'htm', 'html' => 'text/html',
+            'jpg', 'jpeg' => 'image/jpeg',
+            'png' => 'image/png',
+            'pdf' => 'application/pdf',
+            'rtf' => 'application/rtf',
+            'svg' => 'image/svg+xml',
+            'tif', 'tiff' => 'image/tiff',
+            'txt' => 'text/plain',
+            'webp' => 'image/webp',
+            'xhtml' => 'application/xhtml+xml',
+            'xls' => 'application/vnd.ms-excel',
+            'xlsx' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            'xml' => 'application/xml',
+            default => 'application/octet-stream',
+        };
+    }
+
+}

--- a/database/factories/TransactionFactory.php
+++ b/database/factories/TransactionFactory.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace STS\Beankeep\Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Carbon;
+use STS\Beankeep\Models\Transaction;
+
+class TransactionFactory extends Factory
+{
+    protected $model = Transaction::class;
+
+    protected Carbon $startOfYear;
+
+    public function definition(): array
+    {
+        return [
+            'memo' => $this->memo(),
+            'date' => $this->date(),
+        ];
+    }
+
+    protected function memo(): string
+    {
+        $numWords = $this->faker->numberBetween(3, 7);
+
+        return implode(' ', $this->faker->words($numWords));
+    }
+
+    protected function date(): Carbon
+    {
+        $dayOfYear = $this->faker->numberBetween(0, 364);
+
+        return $this->startOfYear()->addDays($dayOfYear);
+    }
+
+    protected function startOfYear(): Carbon
+    {
+        return (
+            $this->startOfYear ??= Carbon::now()->startOfYear()
+        )->copy();
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -7,12 +7,14 @@ namespace STS\Beankeep\Database\Seeders;
 use Illuminate\Database\Seeder;
 use STS\Beankeep\Enums\AccountType;
 use STS\Beankeep\Models\Account;
+use STS\Beankeep\Models\Transaction;
 
 class DatabaseSeeder extends Seeder
 {
     public function run(): void
     {
         Account::factory()->createMany($this->accountsAttributes());
+        Transaction::factory()->count(100)->create();
     }
 
     protected function accountsAttributes(): array

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Collection;
 use STS\Beankeep\Enums\AccountType;
 use STS\Beankeep\Models\Account;
 use STS\Beankeep\Models\LineItem;
+use STS\Beankeep\Models\SourceDocument;
 use STS\Beankeep\Models\Transaction;
 
 class DatabaseSeeder extends Seeder
@@ -30,6 +31,11 @@ class DatabaseSeeder extends Seeder
         Transaction::all()->each(function (Transaction $transaction) {
             foreach ($this->randomUnsavedLineItems() as $lineItem) {
                 $transaction->lineItems()->save($lineItem);
+            }
+
+            if ($this->shouldHaveSourceDocument()) {
+                $sourceDocument = SourceDocument::factory()->make();
+                $transaction->sourceDocuments()->save($sourceDocument);
             }
 
             if ($this->shouldPostTransaction()) {
@@ -58,6 +64,11 @@ class DatabaseSeeder extends Seeder
     public function amount(): int
     {
         return $this->faker->numberBetween(1, 1500) * 100;
+    }
+
+    public function shouldHaveSourceDocument(): bool
+    {
+        return $this->faker->numberBetween(1, 5) % 5 != 0;
     }
 
     public function shouldPostTransaction(): bool

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace STS\Beankeep\Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use STS\Beankeep\Enums\AccountType;
+use STS\Beankeep\Models\Account;
+
+class DatabaseSeeder extends Seeder
+{
+    public function run(): void
+    {
+        Account::factory()->createMany($this->accountsAttributes());
+    }
+
+    protected function accountsAttributes(): array
+    {
+        return [
+            ['number' => '1000', 'name' => 'Assets',              'type' => AccountType::Asset],
+            ['number' => '1100', 'name' => 'Cash',                'type' => AccountType::Asset],
+            ['number' => '1200', 'name' => 'Accounts Receivable', 'type' => AccountType::Asset],
+            ['number' => '1300', 'name' => 'Equipment',           'type' => AccountType::Asset],
+            ['number' => '2000', 'name' => 'Liabilities',         'type' => AccountType::Liability],
+            ['number' => '2100', 'name' => 'Accounts Payable',    'type' => AccountType::Liability],
+            ['number' => '3000', 'name' => 'Equity',              'type' => AccountType::Equity],
+            ['number' => '3100', 'name' => 'Capital',             'type' => AccountType::Equity],
+            ['number' => '4000', 'name' => 'Revenue',             'type' => AccountType::Revenue],
+            ['number' => '4100', 'name' => 'Sales Income',        'type' => AccountType::Revenue],
+            ['number' => '4200', 'name' => 'Consulting Income',   'type' => AccountType::Revenue],
+            ['number' => '5000', 'name' => 'Expenses',            'type' => AccountType::Expense],
+        ];
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -55,8 +55,7 @@ class DatabaseSeeder extends Seeder
 
     public function shouldPostTransaction(): bool
     {
-        // TODO(zmd):: randomly decide whether to actually post the transaction
-        return true;
+        return $this->randomNumber(1, 5) % 5 == 0;
     }
 
     protected function accountsAttributes(): array

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace STS\Beankeep\Database\Seeders;
 
+use Faker\Factory;
+use Faker\Generator;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Collection;
 use STS\Beankeep\Enums\AccountType;
@@ -13,6 +15,13 @@ use STS\Beankeep\Models\Transaction;
 
 class DatabaseSeeder extends Seeder
 {
+    protected Generator $faker;
+
+    public function __construct()
+    {
+        $this->faker = Factory::create();
+    }
+
     public function run(): void
     {
         Account::factory()->createMany($this->accountsAttributes());
@@ -34,14 +43,12 @@ class DatabaseSeeder extends Seeder
     {
         $accounts = Account::all();
 
-        [$debitAccount, $creditAccount] = $accounts->random(2)
+        [$debitAccount, $creditAccount] = $accounts->random(2);
         $amount = $this->amount();
 
-        // TODO(zmd): implement the actual line item factory so this works
         $debitLineItem = LineItem::factory()->make([ 'debit' => $amount ]);
         $debitLineItem->account()->associate($debitAccount);
 
-        // TODO(zmd): implement the actual line item factory so this works
         $creditLineItem = LineItem::factory()->make([ 'credit' => $amount ]);
         $creditLineItem->account()->associate($creditAccount);
 
@@ -50,12 +57,12 @@ class DatabaseSeeder extends Seeder
 
     public function amount(): int
     {
-        return $this->numberBetween(1, 1500) * 100;
+        return $this->faker->numberBetween(1, 1500) * 100;
     }
 
     public function shouldPostTransaction(): bool
     {
-        return $this->randomNumber(1, 5) % 5 == 0;
+        return $this->faker->numberBetween(1, 5) % 5 == 0;
     }
 
     protected function accountsAttributes(): array

--- a/src/Models/Account.php
+++ b/src/Models/Account.php
@@ -4,11 +4,15 @@ declare(strict_types=1);
 
 namespace STS\Beankeep\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use STS\Beankeep\Database\Factories\AccountFactory;
 use STS\Beankeep\Enums\AccountType;
 
 final class Account extends Beankeeper
 {
+    use HasFactory;
+
     protected $table = 'beankeep_accounts';
 
     protected $fillable = [
@@ -24,5 +28,10 @@ final class Account extends Beankeeper
     public function lineItems(): HasMany
     {
         return $this->hasMany(LineItem::class);
+    }
+
+    protected static function newFactory()
+    {
+        return AccountFactory::new();
     }
 }

--- a/src/Models/Account.php
+++ b/src/Models/Account.php
@@ -25,13 +25,13 @@ final class Account extends Beankeeper
         'type' => AccountType::class,
     ];
 
-    public function lineItems(): HasMany
-    {
-        return $this->hasMany(LineItem::class);
-    }
-
     protected static function newFactory()
     {
         return AccountFactory::new();
+    }
+
+    public function lineItems(): HasMany
+    {
+        return $this->hasMany(LineItem::class);
     }
 }

--- a/src/Models/LineItem.php
+++ b/src/Models/LineItem.php
@@ -4,10 +4,14 @@ declare(strict_types=1);
 
 namespace STS\Beankeep\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use STS\Beankeep\Database\Factories\LineItemFactory;
 
 final class LineItem extends Beankeeper
 {
+    use HasFactory;
+
     protected $table = 'beankeep_line_items';
 
     protected $fillable = [
@@ -27,6 +31,11 @@ final class LineItem extends Beankeeper
         static::saving(function (LineItem $lineItem) {
             return $lineItem->isDebit() xor $lineItem->isCredit();
         });
+    }
+
+    protected static function newFactory()
+    {
+        return LineItemFactory::new();
     }
 
     public function account(): BelongsTo

--- a/src/Models/SourceDocument.php
+++ b/src/Models/SourceDocument.php
@@ -5,9 +5,13 @@ declare(strict_types=1);
 namespace STS\Beankeep\Models;
 
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use STS\Beankeep\Database\Factories\SourceDocumentFactory;
 
 final class SourceDocument extends Beankeeper
 {
+    use HasFactory;
+
     protected $table = 'beankeep_source_documents';
 
     protected $fillable = [
@@ -21,6 +25,11 @@ final class SourceDocument extends Beankeeper
     protected $casts = [
         'date' => 'date',
     ];
+
+    protected static function newFactory()
+    {
+        return SourceDocumentFactory::new();
+    }
 
     public function transaction(): BelongsTo
     {

--- a/src/Models/Transaction.php
+++ b/src/Models/Transaction.php
@@ -4,10 +4,14 @@ declare(strict_types=1);
 
 namespace STS\Beankeep\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use STS\Beankeep\Database\Factories\TransactionFactory;
 
 final class Transaction extends Beankeeper
 {
+    use HasFactory;
+
     protected $table = 'beankeep_transactions';
 
     protected $fillable = [
@@ -31,6 +35,11 @@ final class Transaction extends Beankeeper
                 return $transaction->canPost();
             }
         });
+    }
+
+    protected static function newFactory()
+    {
+        return TransactionFactory::new();
     }
 
     public function lineItems(): HasMany

--- a/tests/TestSupport/Traits/BeanConstructors.php
+++ b/tests/TestSupport/Traits/BeanConstructors.php
@@ -12,6 +12,7 @@ use STS\Beankeep\Models\Account;
 use STS\Beankeep\Models\LineItem;
 use STS\Beankeep\Models\SourceDocument;
 use STS\Beankeep\Models\Transaction;
+use STS\Beankeep\Database\Factories\SourceDocumentFactory;
 
 trait BeanConstructors
 {
@@ -124,7 +125,7 @@ trait BeanConstructors
         ?string $attachment = null,
     ): SourceDocument {
         if (is_null($mimeType)) {
-            $mimeType = $this->mime($filename);
+            $mimeType = SourceDocumentFactory::mime($filename);
         }
 
         if (is_null($attachment)) {
@@ -140,34 +141,6 @@ trait BeanConstructors
         $sourceDoc->transaction()->associate($transaction)->save();
 
         return $sourceDoc;
-    }
-
-    protected function mime(string $filename): string
-    {
-        $parts = explode('.', $filename);
-        $extension = end($parts);
-
-        return match($extension) {
-            'bmp' => 'image/bmp',
-            'csv' => 'text/csv',
-            'doc' => 'application/msword',
-            'docx' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-            'gif' => 'image/gif',
-            'htm', 'html' => 'text/html',
-            'jpg', 'jpeg' => 'image/jpeg',
-            'png' => 'image/png',
-            'pdf' => 'application/pdf',
-            'rtf' => 'application/rtf',
-            'svg' => 'image/svg+xml',
-            'tif', 'tiff' => 'image/tiff',
-            'txt' => 'text/plain',
-            'webp' => 'image/webp',
-            'xhtml' => 'application/xhtml+xml',
-            'xls' => 'application/vnd.ms-excel',
-            'xlsx' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-            'xml' => 'application/xml',
-            default => 'application/octet-stream',
-        };
     }
 
     protected function simpleTransactor(?array $accounts = null): Closure


### PR DESCRIPTION
Create the factories and a database seeder to use for testing, development, and demoing. Later we can refine this to make the generated data a bit more plausible looking, and expand it to span years, etc.

Seeder can be used from package consumers like so:

```
$ php artisan db:seed --class="STS\\Beankeep\\Database\\Seeders\\DatabaseSeeder"
```

Fixes #8. Closes #9.