### PR TITLE
LineItem: add useful scopes (#12)

### DIFF
--- a/src/Models/Account.php
+++ b/src/Models/Account.php
@@ -35,8 +35,8 @@ final class Account extends Beankeeper
         return $this->hasMany(LineItem::class);
     }
 
-    public function ledger(): HasMany
+    public function ledger(?iterable $period = null): HasMany
     {
-        return $this->lineItems()->ledger();
+        return $this->lineItems()->ledger($period);
     }
 }

--- a/src/Models/Account.php
+++ b/src/Models/Account.php
@@ -35,7 +35,7 @@ final class Account extends Beankeeper
         return $this->hasMany(LineItem::class);
     }
 
-    public function ledger(?iterable $period = null): HasMany
+    public function ledgerLineItems(?iterable $period = null): HasMany
     {
         return $this->lineItems()->ledger($period);
     }

--- a/src/Models/Account.php
+++ b/src/Models/Account.php
@@ -34,4 +34,9 @@ final class Account extends Beankeeper
     {
         return $this->hasMany(LineItem::class);
     }
+
+    public function ledger(): HasMany
+    {
+        return $this->lineItems()->ledger();
+    }
 }

--- a/src/Models/LineItem.php
+++ b/src/Models/LineItem.php
@@ -66,7 +66,9 @@ final class LineItem extends Beankeeper
 
     public function scopePeriod(Builder $query, CarbonPeriod $period): void
     {
-        // TODO(zmd): implement me
+        $query->whereHas('transaction', function (Builder $query) use ($period) {
+            $query->whereBetween('date', $period);
+        });
     }
 
     public function scopeAccount(Builder $query, Account $account): void

--- a/src/Models/LineItem.php
+++ b/src/Models/LineItem.php
@@ -89,12 +89,14 @@ final class LineItem extends Beankeeper
 
     public function scopeDebits(Builder $query): void
     {
-        // TODO(zmd): implement me
+        $query->where('debit', '>', 0)
+            ->where('credit', 0);
     }
 
     public function scopeCredits(Builder $query): void
     {
-        // TODO(zmd): implement me
+        $query->where('credit', '>', 0)
+            ->where('debit', 0);
     }
 
     public function isDebit(): bool

--- a/src/Models/LineItem.php
+++ b/src/Models/LineItem.php
@@ -74,6 +74,16 @@ final class LineItem extends Beankeeper
         // TODO(zmd): implement me
     }
 
+    public function scopeDebits(Builder $query): void
+    {
+        // TODO(zmd): implement me
+    }
+
+    public function scopeCredits(Builder $query): void
+    {
+        // TODO(zmd): implement me
+    }
+
     public function isDebit(): bool
     {
         return $this->debit > 0;

--- a/src/Models/LineItem.php
+++ b/src/Models/LineItem.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace STS\Beankeep\Models;
 
 use Carbon\CarbonPeriod;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use STS\Beankeep\Database\Factories\LineItemFactory;
@@ -51,7 +52,16 @@ final class LineItem extends Beankeeper
 
     public function scopePosted(Builder $query): void
     {
-        // TODO(zmd): implement me
+        $query->whereHas('transaction', function (Builder $query) {
+            $query->where('posted', true);
+        });
+    }
+
+    public function scopePending(Builder $query): void
+    {
+        $query->whereHas('transaction', function (Builder $query) {
+            $query->where('posted', false);
+        });
     }
 
     public function scopePeriod(Builder $query, CarbonPeriod $period): void
@@ -59,7 +69,7 @@ final class LineItem extends Beankeeper
         // TODO(zmd): implement me
     }
 
-    public function scopeLedger(Builder $query, Account $account): void
+    public function scopeAccount(Builder $query, Account $account): void
     {
         // TODO(zmd): implement me
     }

--- a/src/Models/LineItem.php
+++ b/src/Models/LineItem.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace STS\Beankeep\Models;
 
+use Carbon\CarbonPeriod;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use STS\Beankeep\Database\Factories\LineItemFactory;
@@ -46,6 +47,21 @@ final class LineItem extends Beankeeper
     public function transaction(): BelongsTo
     {
         return $this->belongsTo(Transaction::class);
+    }
+
+    public function scopePosted(Builder $query): void
+    {
+        // TODO(zmd): implement me
+    }
+
+    public function scopePeriod(Builder $query, CarbonPeriod $period): void
+    {
+        // TODO(zmd): implement me
+    }
+
+    public function scopeLedger(Builder $query, Account $account): void
+    {
+        // TODO(zmd): implement me
     }
 
     public function isDebit(): bool

--- a/tests/Feature/AccountLedgerTest.php
+++ b/tests/Feature/AccountLedgerTest.php
@@ -28,8 +28,17 @@ final class AccountLedgerTest extends TestCase
         $this->threeMonthsOfTransactions();
 
         $account = $this->account('cash');
+        $ledger = $account->ledger;
 
-        $this->assertEquals(2, $account->ledger()->count());
+        $this->assertEquals(2, $ledger->count());
+
+        $this->assertEquals(1500, $ledger[0]->credit);
+        $this->assertTrue($ledger[0]->transaction->posted);
+        $this->assertEquals($this->getDate(thisYear: '1/10'), $ledger[0]->transaction->date);
+
+        $this->assertEquals(45000, $ledger[1]->credit);
+        $this->assertTrue($ledger[1]->transaction->posted);
+        $this->assertEquals($this->getDate(thisYear: '2/1'), $ledger[1]->transaction->date);
     }
 
     public function testItCanGetLedgerTransactionsForSpecificPeriod(): void
@@ -37,9 +46,18 @@ final class AccountLedgerTest extends TestCase
         $this->threeMonthsOfTransactions();
 
         $account = $this->account('cash');
+        $janLedger = $this->account('cash')->ledger($this->janPeriod())->get();
+        $febLedger = $this->account('cash')->ledger($this->febPeriod())->get();
 
-        $this->assertEquals(1, $account->ledger($this->janPeriod())->count());
-        $this->assertEquals(1, $account->ledger($this->febPeriod())->count());
+        $this->assertEquals(1, $janLedger->count());
+        $this->assertEquals(1500, $janLedger[0]->credit);
+        $this->assertTrue($janLedger[0]->transaction->posted);
+        $this->assertEquals($this->getDate(thisYear: '1/10'), $janLedger[0]->transaction->date);
+
+        $this->assertEquals(1, $febLedger->count());
+        $this->assertEquals(45000, $febLedger[0]->credit);
+        $this->assertTrue($febLedger[0]->transaction->posted);
+        $this->assertEquals($this->getDate(thisYear: '2/1'), $febLedger[0]->transaction->date);
     }
 
     // =======================================================================

--- a/tests/Feature/AccountLedgerTest.php
+++ b/tests/Feature/AccountLedgerTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace STS\Beankeep\Tests\Feature;
+
+use Carbon\CarbonPeriod;
+use STS\Beankeep\Database\Factories\Support\HasRelativeTransactor;
+use STS\Beankeep\Tests\TestCase;
+use STS\Beankeep\Tests\TestSupport\Traits\CanCreateAccounts;
+
+final class AccountLedgerTest extends TestCase
+{
+    use CanCreateAccounts;
+    use HasRelativeTransactor;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->createAccounts();
+    }
+
+    public function testItCanGetLedgerTransactionsForGivenPeriod(): void
+    {
+        // TODO(zmd): implement me
+        $this->assertTrue(false);
+    }
+
+    // =======================================================================
+
+    protected function janPeriod(): CarbonPeriod
+    {
+        $start = $this->getDate(thisYear: '1/1');
+        $end = $start->endOfMonth();
+
+        return $start->daysUntil($end);
+    }
+
+    protected function febPeriod(): CarbonPeriod
+    {
+        $start = $this->getDate(thisYear: '2/1');
+        $end = $start->endOfMonth();
+
+        return $start->dayUntil($end);
+    }
+
+    protected function threeMonthsOfTransactions(): void
+    {
+        $this->lastYear('12/25')
+            ->transact('initial owner contribution')
+            ->line('cash', dr: 10000.00)
+            ->line('capital', cr: 10000.00)
+            ->doc('contribution-moa.pdf')
+            ->post();
+
+        $this->thisYear('1/5')
+            ->transact('develpment services')
+            ->line('accounts-receivable', dr: 1200.00)
+            ->line('services-revenue', cr: 1200.00)
+            ->doc("invoice-99.pdf")
+            ->post();
+
+        $this->thisYear('1/10')
+            ->transact('register domain')
+            ->line('cost-of-services', dr: 15.00)
+            ->line('cash', cr: 15.00)
+            ->doc('namecheap-receipt.pdf')
+            ->post();
+
+        $this->thisYear('1/20')
+            ->transact('2 computers from computers-ᴙ-us')
+            ->line('equipment', dr: 5000.00)
+            ->line('accounts-payable', cr: 5000.00)
+            ->doc('computers-ᴙ-us-receipt.pdf')
+            ->post();
+
+        $this->thisYear('2/1')
+            ->transact("pay office space rent - feb")
+            ->line('rent-expense', dr: 450.00)
+            ->line('cash', cr: 450.00)
+            ->doc("ck-no-1337-scan.pdf")
+            ->post();
+
+        $this->thisYear('2/12')
+            ->transact('technical consulting services')
+            ->line('accounts-receivable', dr: 240.00)
+            ->line('services-revenue', cr: 240.00)
+            ->doc("invoice-100.pdf")
+            ->post();
+
+        $this->thisYear('2/16')
+            ->transact('ck no. 1338 - pay computers-ᴙ-us invoice')
+            ->line('accounts-payable', dr: 5000.00)
+            ->line('cash', cr: 5000.00)
+            ->doc('ck-no-1338-scan.pdf')
+            ->doc('computers-ᴙ-us-invoice-no-42.pdf')
+            ->draft();
+
+        $this->thisYear('2/26')
+            ->transact('design services')
+            ->line('accounts-receivable', dr: 480.00)
+            ->line('services-revenue', cr: 480.00)
+            ->doc("invoice-101.pdf")
+            ->draft();
+    }
+}

--- a/tests/Feature/AccountLedgerTest.php
+++ b/tests/Feature/AccountLedgerTest.php
@@ -20,10 +20,16 @@ final class AccountLedgerTest extends TestCase
         $this->createAccounts();
     }
 
-    public function testItCanGetLedgerTransactionsForGivenPeriod(): void
+    // NOTE(zmd): right now the default period is the current calendar year; we
+    //   will need to update this test once we make the default period
+    //   user-configurable
+    public function testItCanGetLedgerTransactionsForDefaultPeriod(): void
     {
-        // TODO(zmd): implement me
-        $this->assertTrue(false);
+        $this->threeMonthsOfTransactions();
+
+        $account = $this->account('cash');
+
+        $this->assertEquals(2, $account->ledger()->count());
     }
 
     // =======================================================================

--- a/tests/Feature/AccountLedgerTest.php
+++ b/tests/Feature/AccountLedgerTest.php
@@ -32,6 +32,16 @@ final class AccountLedgerTest extends TestCase
         $this->assertEquals(2, $account->ledger()->count());
     }
 
+    public function testItCanGetLedgerTransactionsForSpecificPeriod(): void
+    {
+        $this->threeMonthsOfTransactions();
+
+        $account = $this->account('cash');
+
+        $this->assertEquals(1, $account->ledger($this->janPeriod())->count());
+        $this->assertEquals(1, $account->ledger($this->febPeriod())->count());
+    }
+
     // =======================================================================
 
     protected function janPeriod(): CarbonPeriod

--- a/tests/Feature/AccountLedgerTest.php
+++ b/tests/Feature/AccountLedgerTest.php
@@ -28,17 +28,17 @@ final class AccountLedgerTest extends TestCase
         $this->threeMonthsOfTransactions();
 
         $account = $this->account('cash');
-        $ledger = $account->ledgerLineItems;
+        $ledgerItems = $account->ledgerLineItems;
 
-        $this->assertEquals(2, $ledger->count());
+        $this->assertEquals(2, $ledgerItems->count());
 
-        $this->assertEquals(1500, $ledger[0]->credit);
-        $this->assertTrue($ledger[0]->transaction->posted);
-        $this->assertEquals($this->getDate(thisYear: '1/10'), $ledger[0]->transaction->date);
+        $this->assertEquals(1500, $ledgerItems[0]->credit);
+        $this->assertTrue($ledgerItems[0]->transaction->posted);
+        $this->assertEquals($this->getDate(thisYear: '1/10'), $ledgerItems[0]->transaction->date);
 
-        $this->assertEquals(45000, $ledger[1]->credit);
-        $this->assertTrue($ledger[1]->transaction->posted);
-        $this->assertEquals($this->getDate(thisYear: '2/1'), $ledger[1]->transaction->date);
+        $this->assertEquals(45000, $ledgerItems[1]->credit);
+        $this->assertTrue($ledgerItems[1]->transaction->posted);
+        $this->assertEquals($this->getDate(thisYear: '2/1'), $ledgerItems[1]->transaction->date);
     }
 
     public function testItCanGetLedgerTransactionsForSpecificPeriod(): void
@@ -46,18 +46,18 @@ final class AccountLedgerTest extends TestCase
         $this->threeMonthsOfTransactions();
 
         $account = $this->account('cash');
-        $janLedger = $this->account('cash')->ledgerLineItems($this->janPeriod())->get();
-        $febLedger = $this->account('cash')->ledgerLineItems($this->febPeriod())->get();
+        $janLedgerItems = $this->account('cash')->ledgerLineItems($this->janPeriod())->get();
+        $febLedgerItems = $this->account('cash')->ledgerLineItems($this->febPeriod())->get();
 
-        $this->assertEquals(1, $janLedger->count());
-        $this->assertEquals(1500, $janLedger[0]->credit);
-        $this->assertTrue($janLedger[0]->transaction->posted);
-        $this->assertEquals($this->getDate(thisYear: '1/10'), $janLedger[0]->transaction->date);
+        $this->assertEquals(1, $janLedgerItems->count());
+        $this->assertEquals(1500, $janLedgerItems[0]->credit);
+        $this->assertTrue($janLedgerItems[0]->transaction->posted);
+        $this->assertEquals($this->getDate(thisYear: '1/10'), $janLedgerItems[0]->transaction->date);
 
-        $this->assertEquals(1, $febLedger->count());
-        $this->assertEquals(45000, $febLedger[0]->credit);
-        $this->assertTrue($febLedger[0]->transaction->posted);
-        $this->assertEquals($this->getDate(thisYear: '2/1'), $febLedger[0]->transaction->date);
+        $this->assertEquals(1, $febLedgerItems->count());
+        $this->assertEquals(45000, $febLedgerItems[0]->credit);
+        $this->assertTrue($febLedgerItems[0]->transaction->posted);
+        $this->assertEquals($this->getDate(thisYear: '2/1'), $febLedgerItems[0]->transaction->date);
     }
 
     // =======================================================================

--- a/tests/Feature/AccountLedgerTest.php
+++ b/tests/Feature/AccountLedgerTest.php
@@ -28,7 +28,7 @@ final class AccountLedgerTest extends TestCase
         $this->threeMonthsOfTransactions();
 
         $account = $this->account('cash');
-        $ledger = $account->ledger;
+        $ledger = $account->ledgerLineItems;
 
         $this->assertEquals(2, $ledger->count());
 
@@ -46,8 +46,8 @@ final class AccountLedgerTest extends TestCase
         $this->threeMonthsOfTransactions();
 
         $account = $this->account('cash');
-        $janLedger = $this->account('cash')->ledger($this->janPeriod())->get();
-        $febLedger = $this->account('cash')->ledger($this->febPeriod())->get();
+        $janLedger = $this->account('cash')->ledgerLineItems($this->janPeriod())->get();
+        $febLedger = $this->account('cash')->ledgerLineItems($this->febPeriod())->get();
 
         $this->assertEquals(1, $janLedger->count());
         $this->assertEquals(1500, $janLedger[0]->credit);

--- a/tests/Feature/GeneralLedgerTest.php
+++ b/tests/Feature/GeneralLedgerTest.php
@@ -46,7 +46,7 @@ final class GeneralLedgerTest extends TestCase
 
     public function testItCanModelAJournalWithManyTransactions(): void
     {
-        $this->twoMonthsOfTransactions();
+        $this->threeMonthsOfTransactions();
 
         // NOTE(zmd): later we'll *also* check individual account balances here,
         //   once we have created helpers for doing such in the package.
@@ -55,7 +55,7 @@ final class GeneralLedgerTest extends TestCase
 
     public function testItCanDifferentiateBetweenPostedAndUnpostedLineItems(): void
     {
-        $this->twoMonthsOfTransactions();
+        $this->threeMonthsOfTransactions();
 
         $this->assertEquals(12, LineItem::posted()->count());
         $this->assertEquals(0, LineItem::posted()->sum('debit') - LineItem::posted()->sum('credit'));
@@ -66,7 +66,7 @@ final class GeneralLedgerTest extends TestCase
 
     public function testItCanEasilyOfferAccessToAllLineItemsWithinASpecifiedPeriod(): void
     {
-        $this->twoMonthsOfTransactions();
+        $this->threeMonthsOfTransactions();
 
         $this->assertEquals(6, LineItem::period($this->janPeriod())->count());
         $this->assertEquals(0, LineItem::period($this->janPeriod())->sum('debit') - LineItem::period($this->janPeriod())->sum('credit'));
@@ -80,7 +80,7 @@ final class GeneralLedgerTest extends TestCase
     //   user-configurable
     public function testItCanEasilyOfferAccessToAllLineItemsWithinTheDefaultPeriod(): void
     {
-        $this->twoMonthsOfTransactions();
+        $this->threeMonthsOfTransactions();
 
         $this->assertEquals(14, LineItem::period()->count());
         $this->assertEquals(0, LineItem::period()->sum('debit') - LineItem::period()->sum('credit'));
@@ -88,7 +88,7 @@ final class GeneralLedgerTest extends TestCase
 
     public function testItCanEasilyOfferAccessToTheGeneralLedgerWithinASpecifiedPeriod(): void
     {
-        $this->twoMonthsOfTransactions();
+        $this->threeMonthsOfTransactions();
 
         $this->assertEquals(6, LineItem::ledger($this->janPeriod())->count());
         $this->assertEquals(0, LineItem::ledger($this->janPeriod())->sum('debit') - LineItem::ledger($this->janPeriod())->sum('credit'));
@@ -102,7 +102,7 @@ final class GeneralLedgerTest extends TestCase
     //   user-configurable
     public function testItCanEasilyOfferAccessToTheGeneralLedgerWithinTheDefaultPeriod(): void
     {
-        $this->twoMonthsOfTransactions();
+        $this->threeMonthsOfTransactions();
 
         $this->assertEquals(10, LineItem::ledger()->count());
         $this->assertEquals(0, LineItem::ledger()->sum('debit') - LineItem::ledger()->sum('credit'));
@@ -110,14 +110,14 @@ final class GeneralLedgerTest extends TestCase
 
     public function testItCanGetAllDebitsThatExistInTheSystem(): void
     {
-        $this->twoMonthsOfTransactions();
+        $this->threeMonthsOfTransactions();
 
         $this->assertEquals(8, LineItem::debits()->count());
     }
 
     public function testItCanGetAllCreditsThatExistInTheSystem(): void
     {
-        $this->twoMonthsOfTransactions();
+        $this->threeMonthsOfTransactions();
 
         $this->assertEquals(8, LineItem::credits()->count());
     }
@@ -140,7 +140,7 @@ final class GeneralLedgerTest extends TestCase
         return $start->dayUntil($end);
     }
 
-    protected function twoMonthsOfTransactions(): void
+    protected function threeMonthsOfTransactions(): void
     {
         $this->lastYear('12/25')
             ->transact('initial owner contribution')

--- a/tests/Feature/GeneralLedgerTest.php
+++ b/tests/Feature/GeneralLedgerTest.php
@@ -77,4 +77,30 @@ final class GeneralLedgerTest extends TestCase
         //   once we have created helpers for doing such in the package.
         $this->assertEquals(0, LineItem::sum('debit') - LineItem::sum('credit'));
     }
+
+    public function testItCanDifferentiateBetweenPostedAndUnpostedLineItems(): void
+    {
+        $this->thisYear('1/1')->transact('initial owner contribution')
+            ->line('cash', dr: 10000.00)
+            ->line('capital', cr: 10000.00)
+            ->post();
+
+        $this->thisYear('10/15')->transact('2 computers from computers-r-us')
+            ->line('equipment', dr: 5000.00)
+            ->line('accounts-payable', cr: 5000.00)
+            ->post();
+
+        $this->thisYear('10/16')->transact('ck no. 1337')
+            ->line('accounts-payable', dr: 5000.00)
+            ->line('cash', cr: 5000.00)
+            ->draft();
+
+        $this->assertEquals(4, LineItem::posted()->count());
+        $this->assertEquals(1500000, LineItem::posted()->sum('debit'));
+        $this->assertEquals(1500000, LineItem::posted()->sum('credit'));
+
+        $this->assertEquals(2, LineItem::pending()->count());
+        $this->assertEquals(500000, LineItem::pending()->sum('debit'));
+        $this->assertEquals(500000, LineItem::pending()->sum('credit'));
+    }
 }

--- a/tests/Feature/GeneralLedgerTest.php
+++ b/tests/Feature/GeneralLedgerTest.php
@@ -21,6 +21,8 @@ final class GeneralLedgerTest extends TestCase
         $this->createAccounts();
     }
 
+    // NOTE(zmd): this is basically just a smoke test, making sure things are
+    //   hooked up
     public function testItCanRecordATransactionToTheJournal(): void
     {
         $transaction = $this->thisYear('1/1')->transact('initial owner contribution')
@@ -44,35 +46,7 @@ final class GeneralLedgerTest extends TestCase
 
     public function testItCanModelAJournalWithManyTransactions(): void
     {
-        //
-        //      Date | Account            |        Dr |        Cr | Memo
-        // ==========+====================+===========+===========+======================
-        //  01/01/22 | Cash               |  10000.00 |           | initial owner con...
-        //           |   Capital          |           |  10000.00 |
-        // ----------+--------------------+-----------+-----------+----------------------
-        //  10/15/22 | Equipment          |   5000.00 |           | 2 computers from ...
-        //           |   Accounts Payable |           |   5000.00 |
-        // ----------+--------------------+-----------+-----------+----------------------
-        //  10/16/22 | Accounts Payable   |   5000.00 |           | ck no. 1337
-        //           |   Cash             |           |   5000.00 |
-        // ==========+====================+===========+===========+======================
-        //           | TOTAL (Dr)         |  20000.00 |           |
-        //           |   TOTAL (Cr)       |           |  20000.00 |
-        //
-        $this->thisYear('1/1')->transact('initial owner contribution')
-            ->line('cash', dr: 10000.00)
-            ->line('capital', cr: 10000.00)
-            ->post();
-
-        $this->thisYear('10/15')->transact('2 computers from computers-r-us')
-            ->line('equipment', dr: 5000.00)
-            ->line('accounts-payable', cr: 5000.00)
-            ->post();
-
-        $this->thisYear('10/16')->transact('ck no. 1337')
-            ->line('accounts-payable', dr: 5000.00)
-            ->line('cash', cr: 5000.00)
-            ->post();
+        $this->twoMonthsOfTransactions();
 
         // NOTE(zmd): later we'll *also* check individual account balances here,
         //   once we have created helpers for doing such in the package.
@@ -81,28 +55,13 @@ final class GeneralLedgerTest extends TestCase
 
     public function testItCanDifferentiateBetweenPostedAndUnpostedLineItems(): void
     {
-        $this->thisYear('1/1')->transact('initial owner contribution')
-            ->line('cash', dr: 10000.00)
-            ->line('capital', cr: 10000.00)
-            ->post();
+        $this->twoMonthsOfTransactions();
 
-        $this->thisYear('10/15')->transact('2 computers from computers-r-us')
-            ->line('equipment', dr: 5000.00)
-            ->line('accounts-payable', cr: 5000.00)
-            ->post();
+        $this->assertEquals(10, LineItem::posted()->count());
+        $this->assertEquals(0, LineItem::posted()->sum('debit') - LineItem::posted()->sum('credit'));
 
-        $this->thisYear('10/16')->transact('ck no. 1337')
-            ->line('accounts-payable', dr: 5000.00)
-            ->line('cash', cr: 5000.00)
-            ->draft();
-
-        $this->assertEquals(4, LineItem::posted()->count());
-        $this->assertEquals(1500000, LineItem::posted()->sum('debit'));
-        $this->assertEquals(1500000, LineItem::posted()->sum('credit'));
-
-        $this->assertEquals(2, LineItem::pending()->count());
-        $this->assertEquals(500000, LineItem::pending()->sum('debit'));
-        $this->assertEquals(500000, LineItem::pending()->sum('credit'));
+        $this->assertEquals(4, LineItem::pending()->count());
+        $this->assertEquals(0, LineItem::pending()->sum('debit') - LineItem::pending()->sum('credit'));
     }
 
     public function testItCanEasilyOfferAccessToAllLineItemsWithinASpecifiedPeriod(): void
@@ -110,9 +69,15 @@ final class GeneralLedgerTest extends TestCase
         $this->twoMonthsOfTransactions();
 
         $this->assertEquals(14, LineItem::all()->count());
+
         $this->assertEquals(6, LineItem::period($this->janPeriod())->count());
+        $this->assertEquals(0, LineItem::period($this->janPeriod())->sum('debit') - LineItem::period($this->janPeriod())->sum('credit'));
+
         $this->assertEquals(8, LineItem::period($this->febPeriod())->count());
+        $this->assertEquals(0, LineItem::period($this->febPeriod())->sum('debit') - LineItem::period($this->febPeriod())->sum('credit'));
     }
+
+    // =======================================================================
 
     protected function janPeriod(): CarbonPeriod
     {
@@ -173,13 +138,13 @@ final class GeneralLedgerTest extends TestCase
             ->line('cash', cr: 5000.00)
             ->doc('ck-no-1338-scan.pdf')
             ->doc('computers-ᴙ-us-invoice-no-42.pdf')
-            ->post();
+            ->draft();
 
         $this->thisYear('2/26')
             ->transact('design services')
             ->line('accounts-receivable', dr: 480.00)
             ->line('services-revenue', cr: 480.00)
             ->doc("invoice-101.pdf")
-            ->post();
+            ->draft();
     }
 }

--- a/tests/Feature/GeneralLedgerTest.php
+++ b/tests/Feature/GeneralLedgerTest.php
@@ -68,8 +68,6 @@ final class GeneralLedgerTest extends TestCase
     {
         $this->twoMonthsOfTransactions();
 
-        $this->assertEquals(14, LineItem::all()->count());
-
         $this->assertEquals(6, LineItem::period($this->janPeriod())->count());
         $this->assertEquals(0, LineItem::period($this->janPeriod())->sum('debit') - LineItem::period($this->janPeriod())->sum('credit'));
 
@@ -84,13 +82,22 @@ final class GeneralLedgerTest extends TestCase
     {
         $this->twoMonthsOfTransactions();
 
-        $this->assertEquals(14, LineItem::all()->count());
-
         $this->assertEquals(6, LineItem::period($this->janPeriod())->count());
         $this->assertEquals(0, LineItem::period($this->janPeriod())->sum('debit') - LineItem::period($this->janPeriod())->sum('credit'));
 
         $this->assertEquals(8, LineItem::period($this->febPeriod())->count());
         $this->assertEquals(0, LineItem::period($this->febPeriod())->sum('debit') - LineItem::period($this->febPeriod())->sum('credit'));
+    }
+
+    public function testItCanEasilyOfferAccessToTheGeneralLedgerWithinASpecifiedPeriod(): void
+    {
+        $this->twoMonthsOfTransactions();
+
+        $this->assertEquals(6, LineItem::ledger($this->janPeriod())->count());
+        $this->assertEquals(0, LineItem::ledger($this->janPeriod())->sum('debit') - LineItem::ledger($this->janPeriod())->sum('credit'));
+
+        $this->assertEquals(4, LineItem::ledger($this->febPeriod())->count());
+        $this->assertEquals(0, LineItem::ledger($this->febPeriod())->sum('debit') - LineItem::ledger($this->febPeriod())->sum('credit'));
     }
 
     // =======================================================================
@@ -111,6 +118,8 @@ final class GeneralLedgerTest extends TestCase
         return $start->dayUntil($end);
     }
 
+    // TODO(zmd): we need to make this 3 months, and include the prior year (so
+    //   that our "default period" tests are testing something more meaningful)
     protected function twoMonthsOfTransactions(): void
     {
         $this->thisYear('1/1')

--- a/tests/Feature/GeneralLedgerTest.php
+++ b/tests/Feature/GeneralLedgerTest.php
@@ -108,19 +108,19 @@ final class GeneralLedgerTest extends TestCase
         $this->assertEquals(0, LineItem::ledger()->sum('debit') - LineItem::ledger()->sum('credit'));
     }
 
-    /*
     public function testItCanGetAllDebitsThatExistInTheSystem(): void
     {
-        // TODO(zmd): implement me
-    }
-    */
+        $this->twoMonthsOfTransactions();
 
-    /*
+        $this->assertEquals(8, LineItem::debits()->count());
+    }
+
     public function testItCanGetAllCreditsThatExistInTheSystem(): void
     {
-        // TODO(zmd): implement me
+        $this->twoMonthsOfTransactions();
+
+        $this->assertEquals(8, LineItem::credits()->count());
     }
-    */
 
     // =======================================================================
 

--- a/tests/Feature/GeneralLedgerTest.php
+++ b/tests/Feature/GeneralLedgerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace STS\Beankeep\Tests\Feature;
 
+use Carbon\CarbonPeriod;
 use STS\Beankeep\Database\Factories\Support\HasRelativeTransactor;
 use STS\Beankeep\Models\LineItem;
 use STS\Beankeep\Tests\TestCase;
@@ -102,5 +103,83 @@ final class GeneralLedgerTest extends TestCase
         $this->assertEquals(2, LineItem::pending()->count());
         $this->assertEquals(500000, LineItem::pending()->sum('debit'));
         $this->assertEquals(500000, LineItem::pending()->sum('credit'));
+    }
+
+    public function testItCanEasilyOfferAccessToAllLineItemsWithinASpecifiedPeriod(): void
+    {
+        $this->twoMonthsOfTransactions();
+
+        $this->assertEquals(14, LineItem::all()->count());
+        $this->assertEquals(6, LineItem::period($this->janPeriod())->count());
+        $this->assertEquals(8, LineItem::period($this->febPeriod())->count());
+    }
+
+    protected function janPeriod(): CarbonPeriod
+    {
+        $start = $this->getDate(thisYear: '1/1');
+        $end = $start->endOfMonth();
+
+        return $start->daysUntil($end);
+    }
+
+    protected function febPeriod(): CarbonPeriod
+    {
+        $start = $this->getDate(thisYear: '2/1');
+        $end = $start->endOfMonth();
+
+        return $start->dayUntil($end);
+    }
+
+    protected function twoMonthsOfTransactions(): void
+    {
+        $this->thisYear('1/1')
+            ->transact('initial owner contribution')
+            ->line('cash', dr: 10000.00)
+            ->line('capital', cr: 10000.00)
+            ->doc('contribution-moa.pdf')
+            ->post();
+
+        $this->thisYear('1/10')
+            ->transact('register domain')
+            ->line('cost-of-services', dr: 15.00)
+            ->line('cash', cr: 15.00)
+            ->doc('namecheap-receipt.pdf')
+            ->post();
+
+        $this->thisYear('1/20')
+            ->transact('2 computers from computers-ᴙ-us')
+            ->line('equipment', dr: 5000.00)
+            ->line('accounts-payable', cr: 5000.00)
+            ->doc('computers-ᴙ-us-receipt.pdf')
+            ->post();
+
+        $this->thisYear('2/1')
+            ->transact("pay office space rent - feb")
+            ->line('rent-expense', dr: 450.00)
+            ->line('cash', cr: 450.00)
+            ->doc("ck-no-1337-scan.pdf")
+            ->post();
+
+        $this->thisYear('2/12')
+            ->transact('technical consulting services')
+            ->line('accounts-receivable', dr: 240.00)
+            ->line('services-revenue', cr: 240.00)
+            ->doc("invoice-100.pdf")
+            ->post();
+
+        $this->thisYear('2/16')
+            ->transact('ck no. 1338 - pay computers-ᴙ-us invoice')
+            ->line('accounts-payable', dr: 5000.00)
+            ->line('cash', cr: 5000.00)
+            ->doc('ck-no-1338-scan.pdf')
+            ->doc('computers-ᴙ-us-invoice-no-42.pdf')
+            ->post();
+
+        $this->thisYear('2/26')
+            ->transact('design services')
+            ->line('accounts-receivable', dr: 480.00)
+            ->line('services-revenue', cr: 480.00)
+            ->doc("invoice-101.pdf")
+            ->post();
     }
 }

--- a/tests/Feature/GeneralLedgerTest.php
+++ b/tests/Feature/GeneralLedgerTest.php
@@ -57,7 +57,7 @@ final class GeneralLedgerTest extends TestCase
     {
         $this->twoMonthsOfTransactions();
 
-        $this->assertEquals(10, LineItem::posted()->count());
+        $this->assertEquals(12, LineItem::posted()->count());
         $this->assertEquals(0, LineItem::posted()->sum('debit') - LineItem::posted()->sum('credit'));
 
         $this->assertEquals(4, LineItem::pending()->count());
@@ -108,6 +108,20 @@ final class GeneralLedgerTest extends TestCase
         $this->assertEquals(0, LineItem::ledger()->sum('debit') - LineItem::ledger()->sum('credit'));
     }
 
+    /*
+    public function testItCanGetAllDebitsThatExistInTheSystem(): void
+    {
+        // TODO(zmd): implement me
+    }
+    */
+
+    /*
+    public function testItCanGetAllCreditsThatExistInTheSystem(): void
+    {
+        // TODO(zmd): implement me
+    }
+    */
+
     // =======================================================================
 
     protected function janPeriod(): CarbonPeriod
@@ -126,15 +140,20 @@ final class GeneralLedgerTest extends TestCase
         return $start->dayUntil($end);
     }
 
-    // TODO(zmd): we need to make this 3 months, and include the prior year (so
-    //   that our "default period" tests are testing something more meaningful)
     protected function twoMonthsOfTransactions(): void
     {
-        $this->thisYear('1/1')
+        $this->lastYear('12/25')
             ->transact('initial owner contribution')
             ->line('cash', dr: 10000.00)
             ->line('capital', cr: 10000.00)
             ->doc('contribution-moa.pdf')
+            ->post();
+
+        $this->thisYear('1/5')
+            ->transact('develpment services')
+            ->line('accounts-receivable', dr: 1200.00)
+            ->line('services-revenue', cr: 1200.00)
+            ->doc("invoice-99.pdf")
             ->post();
 
         $this->thisYear('1/10')

--- a/tests/Feature/GeneralLedgerTest.php
+++ b/tests/Feature/GeneralLedgerTest.php
@@ -97,6 +97,14 @@ final class GeneralLedgerTest extends TestCase
         $this->assertEquals(0, LineItem::ledger($this->febPeriod())->sum('debit') - LineItem::ledger($this->febPeriod())->sum('credit'));
     }
 
+    public function testItCanEasilyOfferAccessToTheGeneralLedgerWithinTheDefaultPeriod(): void
+    {
+        $this->twoMonthsOfTransactions();
+
+        $this->assertEquals(10, LineItem::ledger()->count());
+        $this->assertEquals(0, LineItem::ledger()->sum('debit') - LineItem::ledger()->sum('credit'));
+    }
+
     // =======================================================================
 
     protected function janPeriod(): CarbonPeriod

--- a/tests/Feature/GeneralLedgerTest.php
+++ b/tests/Feature/GeneralLedgerTest.php
@@ -82,11 +82,8 @@ final class GeneralLedgerTest extends TestCase
     {
         $this->twoMonthsOfTransactions();
 
-        $this->assertEquals(6, LineItem::period($this->janPeriod())->count());
-        $this->assertEquals(0, LineItem::period($this->janPeriod())->sum('debit') - LineItem::period($this->janPeriod())->sum('credit'));
-
-        $this->assertEquals(8, LineItem::period($this->febPeriod())->count());
-        $this->assertEquals(0, LineItem::period($this->febPeriod())->sum('debit') - LineItem::period($this->febPeriod())->sum('credit'));
+        $this->assertEquals(14, LineItem::period()->count());
+        $this->assertEquals(0, LineItem::period()->sum('debit') - LineItem::period()->sum('credit'));
     }
 
     public function testItCanEasilyOfferAccessToTheGeneralLedgerWithinASpecifiedPeriod(): void

--- a/tests/Feature/GeneralLedgerTest.php
+++ b/tests/Feature/GeneralLedgerTest.php
@@ -77,6 +77,22 @@ final class GeneralLedgerTest extends TestCase
         $this->assertEquals(0, LineItem::period($this->febPeriod())->sum('debit') - LineItem::period($this->febPeriod())->sum('credit'));
     }
 
+    // NOTE(zmd): right now the default period is the current calendar year; we
+    //   will need to update this test once we make the default period
+    //   user-configurable
+    public function testItCanEasilyOfferAccessToAllLineItemsWithinTheDefaultPeriod(): void
+    {
+        $this->twoMonthsOfTransactions();
+
+        $this->assertEquals(14, LineItem::all()->count());
+
+        $this->assertEquals(6, LineItem::period($this->janPeriod())->count());
+        $this->assertEquals(0, LineItem::period($this->janPeriod())->sum('debit') - LineItem::period($this->janPeriod())->sum('credit'));
+
+        $this->assertEquals(8, LineItem::period($this->febPeriod())->count());
+        $this->assertEquals(0, LineItem::period($this->febPeriod())->sum('debit') - LineItem::period($this->febPeriod())->sum('credit'));
+    }
+
     // =======================================================================
 
     protected function janPeriod(): CarbonPeriod

--- a/tests/Feature/GeneralLedgerTest.php
+++ b/tests/Feature/GeneralLedgerTest.php
@@ -97,6 +97,9 @@ final class GeneralLedgerTest extends TestCase
         $this->assertEquals(0, LineItem::ledger($this->febPeriod())->sum('debit') - LineItem::ledger($this->febPeriod())->sum('credit'));
     }
 
+    // NOTE(zmd): right now the default period is the current calendar year; we
+    //   will need to update this test once we make the default period
+    //   user-configurable
     public function testItCanEasilyOfferAccessToTheGeneralLedgerWithinTheDefaultPeriod(): void
     {
         $this->twoMonthsOfTransactions();


### PR DESCRIPTION
* Add scopes to `LineItem` to:
    * Get items within certain date periods
    * Get items based upon whether the parent transaction is in a drafted or posted state
    * Get debit items
    * Get credit items
* Add relationship to `Account` to get the line items that consist of an account ledger

These scopes will aid in the construction of Ledger objects to get account details (such as balance information for a given period).

Closes #12.