### PR TITLE
Transaction: throw when posting fails (#14, #15)

### DIFF
--- a/src/Exceptions/LineItemInvalid.php
+++ b/src/Exceptions/LineItemInvalid.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace STS\Beankeep\Exceptions;
+
+use Exception;
+
+class LineItemInvalid extends Exception
+{
+}

--- a/src/Exceptions/TransactionLineItemsMissing.php
+++ b/src/Exceptions/TransactionLineItemsMissing.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace STS\Beankeep\Exceptions;
+
+use Exception;
+
+class TransactionLineItemsMissing extends Exception
+{
+}

--- a/src/Exceptions/TransactionLineItemsUnbalanced.php
+++ b/src/Exceptions/TransactionLineItemsUnbalanced.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace STS\Beankeep\Exceptions;
+
+use Exception;
+
+class TransactionLineItemsUnbalanced extends Exception
+{
+}

--- a/src/Models/LineItem.php
+++ b/src/Models/LineItem.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon;
 use STS\Beankeep\Database\Factories\LineItemFactory;
+use STS\Beankeep\Exceptions\LineItemInvalid;
 use STS\Beankeep\Support\BeankeepPeriod;
 use STS\Beankeep\Support\LineItemCollection;
 use STS\Beankeep\Support\PriorToDateNormalizer;
@@ -37,8 +38,15 @@ final class LineItem extends Beankeeper
     protected static function booted(): void
     {
         static::saving(function (LineItem $lineItem) {
-            return $lineItem->isDebit() xor $lineItem->isCredit();
+            if (!$lineItem->isDebitOrCredit()) {
+                throw new LineItemInvalid();
+            }
         });
+    }
+
+    protected function isDebitOrCredit(): bool
+    {
+        return $this->isDebit() xor $this->isCredit();
     }
 
     protected static function newFactory()

--- a/src/Models/LineItem.php
+++ b/src/Models/LineItem.php
@@ -39,7 +39,10 @@ final class LineItem extends Beankeeper
     {
         static::saving(function (LineItem $lineItem) {
             if (!$lineItem->isDebitOrCredit()) {
-                throw new LineItemInvalid();
+                throw new LineItemInvalid(
+                    'LineItem must be either a debit or a credit; it may not '
+                    . 'be both at the same time.',
+                );
             }
         });
     }

--- a/src/Models/Transaction.php
+++ b/src/Models/Transaction.php
@@ -35,9 +35,15 @@ final class Transaction extends Beankeeper
         static::saving(function (Transaction $transaction) {
             if ($transaction->posted) {
                 if ($transaction->debitsOrCreditsMissing()) {
-                    throw new TransactionLineItemsMissing();
+                    throw new TransactionLineItemsMissing(
+                        'Transaction must have at least one debit and one '
+                        . 'credit in order to post.',
+                    );
                 } elseif (!$transaction->lineItemsBalance()) {
-                    throw new TransactionLineItemsUnbalanced();
+                    throw new TransactionLineItemsUnbalanced(
+                        "Transaction's line items must balance in order to "
+                        . 'post.',
+                    );
                 }
             }
         });

--- a/tests/Feature/LineItem/DataIntegrityTest.php
+++ b/tests/Feature/LineItem/DataIntegrityTest.php
@@ -6,6 +6,7 @@ namespace STS\Beankeep\Tests\Feature\LineItem;
 
 use Illuminate\Support\Carbon;
 use STS\Beankeep\Enums\AccountType;
+use STS\Beankeep\Exceptions\LineItemInvalid;
 use STS\Beankeep\Models\Account;
 use STS\Beankeep\Models\LineItem;
 use STS\Beankeep\Models\Transaction;
@@ -65,31 +66,29 @@ final class DataIntegrityTest extends TestCase
         $this->assertTrue($lineItem->isCredit());
     }
 
-    // TODO(zmd): update to reflect desire to raise not silently fail a save
     public function testRefusesToCreateWithBothCreditAndDebitAmount(): void
     {
+        $this->expectException(LineItemInvalid::class);
+
         $lineItem = LineItem::create([
             'account_id' => $this->account()->id,
             'transaction_id' => $this->transaction()->id,
             'debit' => 10000,
             'credit' => 10000,
         ]);
-
-        $this->assertFalse($lineItem->exists);
     }
 
-    // TODO(zmd): update to reflect desire to raise not silently fail a save
     public function testRefusesToSaveWithBothCreditAndDebitAmount(): void
     {
         $lineItem = new LineItem(['debit' => 10000, 'credit' => 10000]);
         $lineItem->account_id = $this->account()->id;
         $lineItem->transaction_id = $this->transaction()->id;
 
-        $this->assertFalse($lineItem->save());
-        $this->assertFalse($lineItem->exists);
+        $this->expectException(LineItemInvalid::class);
+
+        $lineItem->save();
     }
 
-    // TODO(zmd): update to reflect desire to raise not silently fail a save
     public function testRefusesToUpdateWithBothCreditAndDebitAmount(): void
     {
         $lineItem = new LineItem(['debit' => 10000, 'credit' => 0]);
@@ -101,35 +100,34 @@ final class DataIntegrityTest extends TestCase
 
         $lineItem->credit = 10000;
 
-        $this->assertFalse($lineItem->save());
-        $this->assertEquals(0, $lineItem->refresh()->credit);
+        $this->expectException(LineItemInvalid::class);
+
+        $lineItem->save();
     }
 
-    // TODO(zmd): update to reflect desire to raise not silently fail a save
     public function testRefusesToCreateWithoutEitherCreditOrDebitAmount(): void
     {
+        $this->expectException(LineItemInvalid::class);
+
         $lineItem = LineItem::create([
             'account_id' => $this->account()->id,
             'transaction_id' => $this->transaction()->id,
             'debit' => 0,
             'credit' => 0,
         ]);
-
-        $this->assertFalse($lineItem->exists);
     }
 
-    // TODO(zmd): update to reflect desire to raise not silently fail a save
     public function testRefusesToSaveWithoutEitherCreditOrDebitAmount(): void
     {
         $lineItem = new LineItem(['debit' => 0, 'credit' => 0]);
         $lineItem->account_id = $this->account()->id;
         $lineItem->transaction_id = $this->transaction()->id;
 
-        $this->assertFalse($lineItem->save());
-        $this->assertFalse($lineItem->exists);
+        $this->expectException(LineItemInvalid::class);
+
+        $lineItem->save();
     }
 
-    // TODO(zmd): update to reflect desire to raise not silently fail a save
     public function testRefusesToUpdateWithoutEitherCreditOrDebitAmount(): void
     {
         $lineItem = new LineItem(['debit' => 10000, 'credit' => 0]);
@@ -141,8 +139,9 @@ final class DataIntegrityTest extends TestCase
 
         $lineItem->debit = 0;
 
-        $this->assertFalse($lineItem->save());
-        $this->assertEquals(10000, $lineItem->refresh()->debit);
+        $this->expectException(LineItemInvalid::class);
+
+        $lineItem->save();
     }
 
     // ------------------------------------------------------------------------

--- a/tests/Feature/LineItem/DataIntegrityTest.php
+++ b/tests/Feature/LineItem/DataIntegrityTest.php
@@ -65,6 +65,7 @@ final class DataIntegrityTest extends TestCase
         $this->assertTrue($lineItem->isCredit());
     }
 
+    // TODO(zmd): update to reflect desire to raise not silently fail a save
     public function testRefusesToCreateWithBothCreditAndDebitAmount(): void
     {
         $lineItem = LineItem::create([
@@ -77,6 +78,7 @@ final class DataIntegrityTest extends TestCase
         $this->assertFalse($lineItem->exists);
     }
 
+    // TODO(zmd): update to reflect desire to raise not silently fail a save
     public function testRefusesToSaveWithBothCreditAndDebitAmount(): void
     {
         $lineItem = new LineItem(['debit' => 10000, 'credit' => 10000]);
@@ -87,6 +89,7 @@ final class DataIntegrityTest extends TestCase
         $this->assertFalse($lineItem->exists);
     }
 
+    // TODO(zmd): update to reflect desire to raise not silently fail a save
     public function testRefusesToUpdateWithBothCreditAndDebitAmount(): void
     {
         $lineItem = new LineItem(['debit' => 10000, 'credit' => 0]);
@@ -102,6 +105,7 @@ final class DataIntegrityTest extends TestCase
         $this->assertEquals(0, $lineItem->refresh()->credit);
     }
 
+    // TODO(zmd): update to reflect desire to raise not silently fail a save
     public function testRefusesToCreateWithoutEitherCreditOrDebitAmount(): void
     {
         $lineItem = LineItem::create([
@@ -114,6 +118,7 @@ final class DataIntegrityTest extends TestCase
         $this->assertFalse($lineItem->exists);
     }
 
+    // TODO(zmd): update to reflect desire to raise not silently fail a save
     public function testRefusesToSaveWithoutEitherCreditOrDebitAmount(): void
     {
         $lineItem = new LineItem(['debit' => 0, 'credit' => 0]);
@@ -124,6 +129,7 @@ final class DataIntegrityTest extends TestCase
         $this->assertFalse($lineItem->exists);
     }
 
+    // TODO(zmd): update to reflect desire to raise not silently fail a save
     public function testRefusesToUpdateWithoutEitherCreditOrDebitAmount(): void
     {
         $lineItem = new LineItem(['debit' => 10000, 'credit' => 0]);

--- a/tests/Feature/Transaction/PostingTest.php
+++ b/tests/Feature/Transaction/PostingTest.php
@@ -255,7 +255,6 @@ final class PostingTest extends TestCase
         $transaction->save();
     }
 
-    // TODO(zmd): update this test, save should throw on fail now
     public function testSaveDisallowsPostingWhenLineItemsDebitAndSplitCreditsDontBalance(): void
     {
         $transaction = $this->thisYear('03/31')
@@ -265,13 +264,12 @@ final class PostingTest extends TestCase
             ->line('cash', cr: 199.99)
             ->draft();
 
-        $transaction->posted = true;
+        $this->expectException(TransactionLineItemsUnbalanced::class);
 
-        $this->assertFalse($transaction->save());
-        $this->assertFalse($transaction->refresh()->posted);
+        $transaction->posted = true;
+        $transaction->save();
     }
 
-    // TODO(zmd): update this test, save should throw on fail now
     public function testSaveDisallowsPostingWhenLineItemsSplitDebitsAndSplitCreditDontBalance(): void
     {
         $transaction = $this->thisYear('05/05')
@@ -282,26 +280,24 @@ final class PostingTest extends TestCase
             ->line('cash', cr: 200.00)
             ->draft();
 
-        $transaction->posted = true;
+        $this->expectException(TransactionLineItemsUnbalanced::class);
 
-        $this->assertFalse($transaction->save());
-        $this->assertFalse($transaction->refresh()->posted);
+        $transaction->posted = true;
+        $transaction->save();
     }
 
-    // TODO(zmd): update this test, save should throw on fail now
     public function testSaveDisallowsPostingWithoutLineItems(): void
     {
         $transaction = $this->thisYear('07/18')
             ->transact('perform services')
             ->draft();
 
-        $transaction->posted = true;
+        $this->expectException(TransactionLineItemsMissing::class);
 
-        $this->assertFalse($transaction->save());
-        $this->assertFalse($transaction->refresh()->posted);
+        $transaction->posted = true;
+        $transaction->save();
     }
 
-    // TODO(zmd): update this test, save should throw on fail now
     public function testSaveNewDisallowsPostingBecauseNoLineItemsArePossiblyAssociatedYet(): void
     {
         $transaction = new Transaction([
@@ -309,13 +305,12 @@ final class PostingTest extends TestCase
             'memo' => 'perform services',
         ]);
 
-        $transaction->posted = true;
+        $this->expectException(TransactionLineItemsMissing::class);
 
-        $this->assertFalse($transaction->save());
-        $this->assertFalse($transaction->exists);
+        $transaction->posted = true;
+        $transaction->save();
     }
 
-    // TODO(zmd): update this test, save should throw on fail now
     public function testSaveRequiresAtLeastOneDebit(): void
     {
         $transaction = $this->thisYear('07/18')
@@ -324,13 +319,12 @@ final class PostingTest extends TestCase
             ->line('revenue', cr: 400.00)
             ->draft();
 
-        $transaction->posted = true;
+        $this->expectException(TransactionLineItemsMissing::class);
 
-        $this->assertFalse($transaction->save());
-        $this->assertFalse($transaction->refresh()->posted);
+        $transaction->posted = true;
+        $transaction->save();
     }
 
-    // TODO(zmd): update this test, save should throw on fail now
     public function testSaveRequiresAtLeastOneCredit(): void
     {
         $transaction = $this->thisYear('07/18')
@@ -339,9 +333,9 @@ final class PostingTest extends TestCase
             ->line('revenue', dr: 400.00)
             ->draft();
 
-        $transaction->posted = true;
+        $this->expectException(TransactionLineItemsMissing::class);
 
-        $this->assertFalse($transaction->save());
-        $this->assertFalse($transaction->refresh()->posted);
+        $transaction->posted = true;
+        $transaction->save();
     }
 }

--- a/tests/Feature/Transaction/PostingTest.php
+++ b/tests/Feature/Transaction/PostingTest.php
@@ -224,6 +224,7 @@ final class PostingTest extends TestCase
         $this->assertFalse($transaction->refresh()->posted);
     }
 
+    // TODO(zmd): update this test, save should throw on fail now
     public function testSaveDisallowsPostingWhenLineItemsDebitsAndCreditsDontBalance(): void
     {
         $transaction = $this->thisYear('07/18')
@@ -238,6 +239,7 @@ final class PostingTest extends TestCase
         $this->assertFalse($transaction->refresh()->posted);
     }
 
+    // TODO(zmd): update this test, save should throw on fail now
     public function testSaveDisallowsPostingWhenLineItemsSplitDebitsAndCreditDontBalance(): void
     {
         $transaction = $this->thisYear('03/31')
@@ -253,6 +255,7 @@ final class PostingTest extends TestCase
         $this->assertFalse($transaction->refresh()->posted);
     }
 
+    // TODO(zmd): update this test, save should throw on fail now
     public function testSaveDisallowsPostingWhenLineItemsDebitAndSplitCreditsDontBalance(): void
     {
         $transaction = $this->thisYear('03/31')
@@ -268,6 +271,7 @@ final class PostingTest extends TestCase
         $this->assertFalse($transaction->refresh()->posted);
     }
 
+    // TODO(zmd): update this test, save should throw on fail now
     public function testSaveDisallowsPostingWhenLineItemsSplitDebitsAndSplitCreditDontBalance(): void
     {
         $transaction = $this->thisYear('05/05')
@@ -284,6 +288,7 @@ final class PostingTest extends TestCase
         $this->assertFalse($transaction->refresh()->posted);
     }
 
+    // TODO(zmd): update this test, save should throw on fail now
     public function testSaveDisallowsPostingWithoutLineItems(): void
     {
         $transaction = $this->thisYear('07/18')
@@ -296,6 +301,7 @@ final class PostingTest extends TestCase
         $this->assertFalse($transaction->refresh()->posted);
     }
 
+    // TODO(zmd): update this test, save should throw on fail now
     public function testSaveNewDisallowsPostingBecauseNoLineItemsArePossiblyAssociatedYet(): void
     {
         $transaction = new Transaction([
@@ -309,6 +315,7 @@ final class PostingTest extends TestCase
         $this->assertFalse($transaction->exists);
     }
 
+    // TODO(zmd): update this test, save should throw on fail now
     public function testSaveRequiresAtLeastOneDebit(): void
     {
         $transaction = $this->thisYear('07/18')
@@ -323,6 +330,7 @@ final class PostingTest extends TestCase
         $this->assertFalse($transaction->refresh()->posted);
     }
 
+    // TODO(zmd): update this test, save should throw on fail now
     public function testSaveRequiresAtLeastOneCredit(): void
     {
         $transaction = $this->thisYear('07/18')

--- a/tests/Feature/Transaction/PostingTest.php
+++ b/tests/Feature/Transaction/PostingTest.php
@@ -6,6 +6,8 @@ namespace STS\Beankeep\Tests\Feature\Transaction;
 
 use Illuminate\Support\Carbon;
 use STS\Beankeep\Database\Factories\Support\HasRelativeTransactor;
+use STS\Beankeep\Exceptions\TransactionLineItemsMissing;
+use STS\Beankeep\Exceptions\TransactionLineItemsUnbalanced;
 use STS\Beankeep\Models\Transaction;
 use STS\Beankeep\Tests\TestCase;
 use STS\Beankeep\Tests\TestSupport\Traits\CanCreateAccounts;
@@ -224,7 +226,6 @@ final class PostingTest extends TestCase
         $this->assertFalse($transaction->refresh()->posted);
     }
 
-    // TODO(zmd): update this test, save should throw on fail now
     public function testSaveDisallowsPostingWhenLineItemsDebitsAndCreditsDontBalance(): void
     {
         $transaction = $this->thisYear('07/18')
@@ -233,13 +234,12 @@ final class PostingTest extends TestCase
             ->line('revenue', cr: 300.00)
             ->draft();
 
-        $transaction->posted = true;
+        $this->expectException(TransactionLineItemsUnbalanced::class);
 
-        $this->assertFalse($transaction->save());
-        $this->assertFalse($transaction->refresh()->posted);
+        $transaction->posted = true;
+        $transaction->save();
     }
 
-    // TODO(zmd): update this test, save should throw on fail now
     public function testSaveDisallowsPostingWhenLineItemsSplitDebitsAndCreditDontBalance(): void
     {
         $transaction = $this->thisYear('03/31')
@@ -249,10 +249,10 @@ final class PostingTest extends TestCase
             ->line('cash', cr: 400.02)
             ->draft();
 
-        $transaction->posted = true;
+        $this->expectException(TransactionLineItemsUnbalanced::class);
 
-        $this->assertFalse($transaction->save());
-        $this->assertFalse($transaction->refresh()->posted);
+        $transaction->posted = true;
+        $transaction->save();
     }
 
     // TODO(zmd): update this test, save should throw on fail now


### PR DESCRIPTION
* `Transaction`: throw an error, rather than silently failing, when attempting to save a transaction as posted when it cannot be legit posted due to data integrity issues surrounding it's constituent `LineItem`s.
* `LineItem`: throw an error, rather than silently failing, when attempting to save a line item as anything except _either_ a debit _xor_ a credit.

Fixes #14. Closes #15.

------

Automated Test Results:

```
OK (173 tests, 301 assertions)
```